### PR TITLE
Change QoS setting from gpu6hours to a100-6hours

### DIFF
--- a/cluster/cluster_config.json
+++ b/cluster/cluster_config.json
@@ -8,7 +8,7 @@
     },
     "basecall": {
         "time": "05:55:00",
-        "qos": "gpu6hours",
+        "qos": "a100-6hours",
         "mem": "100G",
         "cpus": 32,
         "extra": "--partition=a100 --nodes=1 --gres=gpu:4"


### PR DESCRIPTION
As anounced by email the QoS for GPU usage was changed to (gpu)-6hours. We have fixed it in the local files on the cluster already, but it should also be changed here.